### PR TITLE
More coherent Replace

### DIFF
--- a/lib.ua
+++ b/lib.ua
@@ -1,9 +1,10 @@
 # Upscale an array(b) by some amount(a)
 Upscale ← °⍉▽▽⧻⟜:⍉▽▽⧻,⟜:
 # Replace all occurrences of (a) in (c) with (b)
-Replace ← ⍜⊜∘≡⋅∘ /↥≡↻⊙¤¯⇡⧻⟜⌕ ⊃⊙⋅⟜∘⋅¤
+Replace ← ⍜⊜∘≡⋅∘ ⊂⊢:≡/≥◫2./+ ≡↻⊙¤¯⇡⧻⟜⌕⊙⊓.¤
 
 ---
 ⍤⟜≍: [.1_1_2_2 .3_3_4_4] Upscale 2 [1_2 3_4]
 ⍤⟜≍: "xyzracadxyzra" Replace "ab" "xyz" "abracadabra"
+⍤⟜≍: "yyyxxzyyy" Replace "xxx" "xxxxxzxxx" "yyy"
 ---


### PR DESCRIPTION
The old `Replace` didn't care about intersecting matches, but the new one does. I also wrote a test for it.